### PR TITLE
removing serial initialization from ATS_Begin (I'd rather handle that in my main file)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.settings
+/.cproject
+/.project

--- a/ArduinoTestSuite.cpp
+++ b/ArduinoTestSuite.cpp
@@ -173,8 +173,9 @@ char	memoryMsg[48];
 	gYotalErrors	=	0;
 	gTestCount		=	0;
 
-	Serial.begin(9600);
-	delay(100);
+// modified by gaftech: I prefer handling serial init in my main file
+//	Serial.begin(9600);
+//	delay(100);
 	
 	gTestTotalElapsedTime = 0;
 


### PR DESCRIPTION
I think this idea is ok, but we must do that in all the example code.
